### PR TITLE
使用するセクション名をTUIモードで表示させる

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gdamore/tcell/v2"
@@ -28,13 +29,13 @@ var (
 	errorModal *tview.Modal
 )
 
-var inputLabel = "Enter a text: "
+var inputLabel = "Enter a text%s: "
 
 func init() {
 	// initialize tview
 	app = tview.NewApplication()
 
-	inputField = tview.NewInputField().SetLabel(inputLabel).
+	inputField = tview.NewInputField().
 		SetFieldStyle(tcell.StyleDefault.Background(tcell.ColorDefault))
 	inputField.SetBackgroundColor(tcell.ColorDefault)
 
@@ -67,7 +68,11 @@ func Run(iniPath, section string, args []string) error {
 		}
 	}
 
-	inputField.SetText(input).
+	var sectionLabel string
+	if len(section) != 0 {
+		sectionLabel = " (" + section + ")"
+	}
+	inputField.SetLabel(fmt.Sprintf(inputLabel, sectionLabel)).SetText(input).
 		SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 			switch event.Key() {
 			case tcell.KeyEnter:

--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ func main() {
 	flag.Parse()
 
 	args := flag.Args()
-	if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "error: empty value\n")
+	if !isTUIMode && len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "error: %s\n", wepo.ErrEmptyValue)
 		flag.Usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
使用するセクション名をTUIモードで表示させるようにしました。
また、TUIモードを引数無しで起動した時に `empty value` が表示される問題に対応しました。　-> https://github.com/tsuen4/wepo/pull/8/commits/147a0405b712f06e749168fad8ab8432bdd46aeb

### セクション指定している時

![image](https://user-images.githubusercontent.com/40273806/191987330-814b5eb9-4894-4a3f-80d8-e14a926c503b.png)

### セクションを指定していない時

![image](https://user-images.githubusercontent.com/40273806/191987375-0e2598bb-15b5-4b9b-b9a3-35b88392ee16.png)
