### PR TITLE
パイプから入力できるように修正

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -61,7 +60,7 @@ func Run(iniPath, section string, args []string) error {
 		return err
 	}
 
-	input, err := wepo.Input(args, int(os.Stdin.Fd()))
+	input, err := wepo.Input(args)
 	if err != nil {
 		if err != wepo.ErrEmptyValue {
 			return err

--- a/main.go
+++ b/main.go
@@ -26,14 +26,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	args := flag.Args()
-	if !isTUIMode && len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "error: %s\n", wepo.ErrEmptyValue)
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	if err := run(args); err != nil {
+	if err := run(flag.Args()); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
@@ -60,7 +53,7 @@ func shellMode(cfgDirPath, section string, args []string) error {
 		return err
 	}
 
-	input, err := wepo.Input(args, int(os.Stdin.Fd()))
+	input, err := wepo.Input(args)
 	if err != nil {
 		return err
 	}

--- a/pkg/wepo/wepo.go
+++ b/pkg/wepo/wepo.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/tsuen4/wepo/pkg/wepo/config"
-	"golang.org/x/term"
 )
 
 // wepo structure provide the client. wepo holds the config.
@@ -33,25 +32,18 @@ func New(iniPath, section string) (*wepo, error) {
 var ErrEmptyValue = fmt.Errorf("empty value")
 
 // Input returns a string. The string is entered from an argument or pipeline.
-func Input(args []string, fd int) (string, error) {
-	var c string
-
-	// fd: 0 -> default
-	if term.IsTerminal(fd) {
-		c = strings.Join(args, " ")
-	} else {
-		cBytes, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", err
-		}
-		c = string(cBytes)
+func Input(args []string) (string, error) {
+	bytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
 	}
+	input := string(bytes)
 
-	if len(c) == 0 {
+	if len(input) == 0 {
 		return "", ErrEmptyValue
 	}
 
-	return c, nil
+	return input, nil
 }
 
 // PostContents sends content to wepo.WepoConfig.URL


### PR DESCRIPTION
main() に追加していた処理でパイプから入力できないようになっていた。

`os.Stdin.Fd()` と `term.IsTerminal(fd)` が無くても動作したので一旦削除する。